### PR TITLE
v_item_value too short

### DIFF
--- a/source/dynamic_action_plugin_pretius_apex_client_side_validation.sql
+++ b/source/dynamic_action_plugin_pretius_apex_client_side_validation.sql
@@ -170,8 +170,8 @@ wwv_flow_api.create_plugin (
 '  v_item_names DBMS_SQL.VARCHAR2_TABLE;'||unistr('\000a')||
 '  '||unistr('\000a')||
 '  v_item_value v'||
-'archar2(100);'||unistr('\000a')||
-'  v_string varchar2(32000);'||unistr('\000a')||
+'archar2(32767);'||unistr('\000a')||
+'  v_string varchar2(32767);'||unistr('\000a')||
 '  v_test_number number;'||unistr('\000a')||
 '  v_isnumber boolean := false;'||unistr('\000a')||
 'begin'||unistr('\000a')||


### PR DESCRIPTION
Found when using the plug-in with BLOB's filename item. When the filename stored int eh APEX item was longer than 88 characters (APEX prefixes it with "C:\fakepath\") then the validation was failing showing "Error occurred while performing validation."
With "v_item_value varchar2(32767);" all is good (maybe exaggerated with 32K?)